### PR TITLE
Fix compilation issue due on debian 9 stretch

### DIFF
--- a/src/libmath.c
+++ b/src/libmath.c
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 static double inv(double a)
 {
 double v;
-   if (a==0.0) v=HUGE;
+   if (a==0.0) v=HUGE_VAL;
    else v = (double)1.0/a;
    return v;
 }


### PR DESCRIPTION
```
% make
make  all-recursive
make[1]: Entering directory '/home/thomas/workspace/Nife'
Making all in src
make[2]: Entering directory '/home/thomas/workspace/Nife/src'
gcc -DHAVE_CONFIG_H -I. -I..     -g -O2 -MT libmath.o -MD -MP -MF .deps/libmath.Tpo -c -o libmath.o libmath.c
libmath.c: In function ‘inv’:
libmath.c:28:18: error: ‘HUGE’ undeclared (first use in this function)
    if (a==0.0) v=HUGE;
                  ^~~~
libmath.c:28:18: note: each undeclared identifier is reported only once for each function it appears in
Makefile:312: recipe for target 'libmath.o' failed
make[2]: *** [libmath.o] Error 1
make[2]: Leaving directory '/home/thomas/workspace/Nife/src'
Makefile:282: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/home/thomas/workspace/Nife'
Makefile:222: recipe for target 'all' failed
make: *** [all] Error 2
```